### PR TITLE
Skip empty commands

### DIFF
--- a/cli/blecli.go
+++ b/cli/blecli.go
@@ -32,9 +32,14 @@ func BLEShell() {
 	for {
 		fmt.Print("-> ")
 		text, _ := reader.ReadString('\n')
+
 		args := strings.Fields(
 			strings.ReplaceAll(text, "\n", ""),
 		)
+
+                if len(args) == 0 {
+                    continue
+                }
 
 		switch args[0] {
 		case "scan":


### PR DESCRIPTION
Quick fix for crash if idly hitting the return key